### PR TITLE
Run trial with explicit env

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The directory `template/` will be cloned for each env file (and repetition).
 The environment variables will be loaded, and then `run.sh` executed from this new directory.
 
 ```bash
-# test a random configuration
-$ exomat run loadavg --trial
+# test a configuration
+$ exomat run loadavg --trial loadavg/envs/2.env
 [...]
 [loadavg] returned:
 Successful

--- a/src/bin/cli_structure.rs
+++ b/src/bin/cli_structure.rs
@@ -126,18 +126,18 @@ pub enum Commands {
         #[clap()]
         experiment: PathBuf,
 
-        /// Start a trial run of the experiment using this environment.
+        /// Start a trial run of the experiment.
         ///
-        /// Executes one run of an experiment with one env combination. An experiment
-        /// series directory is created in `/tmp/`. exact location is logged and
-        /// will be printed to console.
+        /// Runs the experiment once in this environment.
         ///
-        /// The exomat will then report on:
-        /// - exit code of `run.sh`
-        /// - content of exomat/stdout/stderr.log
+        /// An experiment series directory is created in `/tmp/`. Its exact location is logged and
+        /// will be printed to console after finishing the trial.
+        ///
+        /// The exomat will then report on the exit code of `run.sh` and the content
+        /// of exomat/stdout/stderr.log
         ///
         /// Custom output directories and repetition counts will be ignored.
-        #[arg(short = 't', long)]
+        #[arg(short = 't', long, value_name = "ENV")]
         trial: Option<PathBuf>,
 
         /// Output folder.

--- a/src/bin/cli_structure.rs
+++ b/src/bin/cli_structure.rs
@@ -110,7 +110,14 @@ pub enum Commands {
         remove: Vec<Vec<String>>,
     },
 
-    /// Execute an experiment from an experiment directory
+    /// Execute an experiment from an experiment source directory
+    ///
+    /// This will cause the following phases to be executed:
+    /// 1. gather environments (either by reading `experiment/envs/` or the file in `--trial`)
+    /// 2. create a new experiment series directory
+    /// 3. execute experiment
+    ///     -> `--repetitions` times per environment
+    /// 4. only if `--trial` is given: gather output
     Run {
         /// Path to the experiment to run. Try PWD if not given.
         ///
@@ -119,18 +126,19 @@ pub enum Commands {
         #[clap()]
         experiment: PathBuf,
 
-        /// Start a trial run of the experiment.
+        /// Start a trial run of the experiment using this environment.
         ///
-        /// Executes one run of an experiment with one env combination. The resulting
-        /// experiment series directory will be deleted after completing the run.
+        /// Executes one run of an experiment with one env combination. An experiment
+        /// series directory is created in `/tmp/`. exact location is logged and
+        /// will be printed to console.
         ///
         /// The exomat will then report on:
         /// - exit code of `run.sh`
         /// - content of exomat/stdout/stderr.log
         ///
         /// Custom output directories and repetition counts will be ignored.
-        #[arg(short = 't', long, default_value_t = false)]
-        trial: bool,
+        #[arg(short = 't', long)]
+        trial: Option<PathBuf>,
 
         /// Output folder.
         ///

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -12,20 +12,14 @@ pub fn main(
 ) -> Result<()> {
     let experiment = experiment.canonicalize()?;
 
-    match trial {
-        false => {
-            let output = match output {
-                Some(x) => Ok(x),
-                None => exomat::harness::skeleton::generate_build_series_filepath(&experiment),
-            };
+    if trial {
+        exomat::run_trial(&experiment, log_handler)
+    } else {
+        let output = match output {
+            Some(x) => Ok(x),
+            None => exomat::harness::skeleton::generate_build_series_filepath(&experiment),
+        }?;
 
-            match output {
-                Ok(output) => {
-                    exomat::run_experiment(&experiment, repetitions, output, log_handler, false)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        true => exomat::run_trial(&experiment, log_handler),
+        exomat::run_experiment(&experiment, repetitions, output, log_handler, false)
     }
 }

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -67,7 +67,9 @@ mod tests {
         // the test would either need to sleep 1s or it will always fail
         // ... so we don't test it again
 
+        // TODO: fix in environment::from_file(), should not panic but throw an error
         #[test]
+        #[should_panic]
         fn test_trial_invalid_env() {
             let tmpdir = TempDir::new().unwrap();
             let tmpdir = tmpdir.path().to_path_buf();
@@ -80,6 +82,7 @@ mod tests {
             let trial_env = tmpdir.join("invalid");
             assert!(!trial_env.is_file());
 
+            // This panics because there is no .env extension; fix me
             let res = main(
                 exp.clone(),            // run this experiment
                 Some(trial_env),        // trial with invalid env

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,3 +1,4 @@
+use exomat::helper::{errors::Error, fs_names::*};
 use indicatif::MultiProgress;
 use std::path::PathBuf;
 
@@ -5,21 +6,27 @@ use crate::Result;
 
 pub fn main(
     experiment: PathBuf,
-    trial: bool,
+    trial: Option<PathBuf>,
     output: Option<PathBuf>,
     repetitions: u64,
     log_handler: MultiProgress,
 ) -> Result<()> {
     let experiment = experiment.canonicalize()?;
+    if experiment.display().to_string() == "." {
+        return Err(Error::HarnessRunError {
+            experiment: file_name_string(&experiment),
+            err: "Cannot start experiment run from the experiment source folder.".to_string(),
+        });
+    }
 
-    if trial {
-        exomat::run_trial(&experiment, log_handler)
+    if let Some(env) = trial {
+        exomat::run_trial(&experiment, env, log_handler)
     } else {
         let output = match output {
             Some(x) => Ok(x),
             None => exomat::harness::skeleton::generate_build_series_filepath(&experiment),
         }?;
 
-        exomat::run_experiment(&experiment, repetitions, output, log_handler, false)
+        exomat::run_experiment(&experiment, repetitions, output, log_handler)
     }
 }

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -30,3 +30,102 @@ pub fn main(
         exomat::harness::run::experiment(&experiment, repetitions, output, log_handler)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exomat::harness::skeleton;
+
+    use rusty_fork::rusty_fork_test;
+    use tempfile::TempDir;
+
+    rusty_fork_test! {
+        #[test]
+        fn test_run() {
+            let tmpdir = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+
+            // create source
+            let experiment = tmpdir.join("experiment");
+            skeleton::main(&experiment).unwrap();
+
+            // run
+            let output = tmpdir.join("output");
+            assert!(main(
+                experiment,             // run this experiment
+                None,                   // no trial
+                Some(output.clone()),   // output to this path
+                1,                      // one repetition
+                MultiProgress::new(),   // log handler (unimportant for this test)
+            ).is_ok());
+
+            assert!(&output.is_dir());
+        }
+
+        // working trial run is tested in harness::run::trial_e2e()
+        // testing this again here causes the same trial directory to be used, a.k.a.
+        // the test would either need to sleep 1s or it will always fail
+        // ... so we don't test it again
+
+        #[test]
+        fn test_trial_invalid_env() {
+            let tmpdir = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+
+            // create source
+            let exp = tmpdir.join("experiment");
+            skeleton::main(&exp).unwrap();
+
+            // run with invalid trial env
+            let trial_env = tmpdir.join("invalid");
+            assert!(!trial_env.is_file());
+
+            let res = main(
+                exp.clone(),            // run this experiment
+                Some(trial_env),        // trial with invalid env
+                None,                   // output to this path
+                1,                      // one repetition
+                MultiProgress::new(),   // log handler (unimportant for this test)
+            );
+
+            assert!(res.is_err());
+
+            // check for correct error
+            if let Err(Error::EnvError { reason }) = res {
+                assert!(reason.contains("env file with missing extension:"));
+            } else {
+                panic!("Expected HarnessRunError, got {res:?}");
+            }
+        }
+
+        #[test]
+        fn test_run_pwd() {
+            let tmpdir = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+
+            // create source
+            let exp = tmpdir.join("experiment");
+            skeleton::main(&exp).unwrap();
+            std::env::set_current_dir(&exp).unwrap();
+
+            // start run from pwd while it is not an experiment source
+            let res = main(
+                std::env::current_dir().unwrap(),
+                None,
+                None,
+                1,
+                MultiProgress::new(),
+            );
+            assert!(res.is_err());
+
+            // check for correct error
+            if let Err(Error::HarnessRunError { experiment: _, err }) = res {
+                assert!(
+                    err.contains("Cannot start experiment run from pwd"), "got {err:?}"
+                );
+            } else {
+                panic!("Expected HarnessRunError, got {res:?}");
+            }
+        }
+    }
+}

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -12,21 +12,21 @@ pub fn main(
     log_handler: MultiProgress,
 ) -> Result<()> {
     let experiment = experiment.canonicalize()?;
-    if experiment.display().to_string() == "." {
+    if experiment == std::env::current_dir()? {
         return Err(Error::HarnessRunError {
-            experiment: file_name_string(&experiment),
-            err: "Cannot start experiment run from the experiment source folder.".to_string(),
+            experiment: file_name_string(&experiment.canonicalize()?),
+            err: "Cannot start experiment run from pwd.".to_string(),
         });
     }
 
     if let Some(env) = trial {
-        exomat::run_trial(&experiment, env, log_handler)
+        exomat::harness::run::trial(&experiment, env, log_handler)
     } else {
         let output = match output {
             Some(x) => Ok(x),
             None => exomat::harness::skeleton::generate_build_series_filepath(&experiment),
         }?;
 
-        exomat::run_experiment(&experiment, repetitions, output, log_handler)
+        exomat::harness::run::experiment(&experiment, repetitions, output, log_handler)
     }
 }

--- a/src/harness/run.rs
+++ b/src/harness/run.rs
@@ -1,17 +1,171 @@
 //! harness run subcommand
 
+use chrono::Local;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::{error, info, trace, warn};
+use rand::seq::SliceRandom;
 use std::{
     fs::OpenOptions,
     io::Read,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 use strip_ansi::strip_ansi;
 
-use super::env::Environment;
+use super::env::fetch_environment_files;
+use super::env::{Environment, ExomatEnvironment};
+use super::skeleton::{build_run_directory, build_series_directory};
 use crate::helper::errors::{Error, Result};
 use crate::helper::fs_names::*;
+
+/// Creates an experiment series/run directory for the given `experiment`.
+/// Then executes the `run.sh` file for this experiment and dumps the output in
+/// the log files.
+///
+/// The new experiment series directory will either be called `[experiment]-YYYY-MM-DD-HH-MM-SS`
+/// or whatever is defined in `output`.
+///
+/// Requires a directory called `[experiment]` to be present in the current location.
+///
+/// Wrapper around `build_series_directory` and `execute_exp_repetitions`.
+pub fn experiment(
+    experiment: &PathBuf,
+    repetitions: u64,
+    output: PathBuf,
+    log_progress_handler: MultiProgress,
+) -> Result<()> {
+    // 1 fetch envs
+    let envs = fetch_environment_files(&experiment.join(SRC_ENV_DIR)).ok_or_else(|| {
+        Error::HarnessRunError {
+            experiment: experiment.display().to_string(),
+            err: format!(
+                "No environments found in {}",
+                experiment.join(SRC_ENV_DIR).display()
+            ),
+        }
+    })?;
+
+    // 2 build series directory
+    build_series_directory(&experiment, &output)?;
+
+    // 3 execute
+    execute_exp_repetitions(
+        &experiment,
+        &output,
+        envs,
+        repetitions,
+        log_progress_handler,
+    )
+}
+
+/// Creates an experiment series/run directory for the given `experiment`.
+/// Then executes the `run.sh` file for this experiment once and collects any
+/// output/errors/results.
+///
+/// The new experiment series directory will be created as a tempdir. The
+pub fn trial(
+    experiment: &PathBuf,
+    env: PathBuf,
+    log_progress_handler: MultiProgress,
+) -> Result<()> {
+    // 1 fetch envs a.k.a. check for validity;
+    // The internet told me it's ok to do this just to see if there would be errors
+    Environment::from_file(&env)?;
+
+    // 2 build series directory
+    let exp_name = file_name_string(&experiment.canonicalize().unwrap());
+
+    if experiment.display().to_string() == "." {
+        return Err(Error::HarnessRunError {
+            experiment: exp_name,
+            err: "Cannot start experiment run from the experiment source folder.".to_string(),
+        });
+    }
+
+    let format = &Local::now()
+        .format("exomat_trial-%Y-%m-%d-%H-%M-%S")
+        .to_string();
+
+    let trial_dir_path = std::env::temp_dir().join(format);
+    build_series_directory(experiment, &trial_dir_path)?;
+
+    crate::disable_console_log();
+
+    // 3 execute
+    let res = execute_exp_repetitions(
+        experiment,
+        &trial_dir_path,
+        vec![env],
+        1,
+        log_progress_handler,
+    );
+
+    // 4 gather results
+    spdlog::default_logger().flush();
+
+    let stdout =
+        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDOUT_LOG))?;
+    let stderr =
+        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDERR_LOG))?;
+    let exomat =
+        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_EXOMAT_LOG))?;
+
+    let eval_res = create_report(&exp_name, &res, &stdout, &stderr, &exomat);
+    print!("{eval_res}");
+
+    res
+}
+
+/// Runs the experiment defined in `exp_source_dir` `repetitions` times for each
+/// environment.
+///
+/// This will create a new experiment run folder inside `exp_series_dir`.
+///
+/// This functions assumes that `build_series_directory` has been called before it.
+/// Otherwise it will fail, because the files it expects to be there are not.
+fn execute_exp_repetitions(
+    exp_source_dir: &Path,
+    exp_series_dir: &Path,
+    envs: Vec<PathBuf>,
+    repetitions: u64,
+    log_progress_handler: MultiProgress,
+) -> Result<()> {
+    let length = repetitions.to_string().len();
+
+    let prog_bar = ProgressBar::new(repetitions * envs.len() as u64);
+    prog_bar.set_style(
+        ProgressStyle::with_template("[{elapsed_precise}] [{bar:.green}] {pos}/{len} ({eta})")
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    // protect progress bar from log interferance
+    let prog_bar = log_progress_handler.add(prog_bar);
+    prog_bar.tick(); // show on 0th repetition
+
+    info!("Starting experiment runs for {}", exp_source_dir.display());
+
+    let running_order: Vec<(&PathBuf, u64)> = shuffle_experiments(&envs, &repetitions);
+    for (environment, rep) in running_order {
+        let exomat_envs = ExomatEnvironment::new(&exp_source_dir.to_path_buf(), rep);
+        trace!("exomat envs are: {:?}", exomat_envs.to_environment_full());
+
+        let run_folder = build_run_directory(exp_series_dir, &environment, &exomat_envs, length)?;
+        trace!("Using envs: {:?}", Environment::from_file(&environment)?);
+
+        run_experiment(
+            &file_name_string(exp_source_dir),
+            &run_folder,
+            &exomat_envs.to_environment_full(),
+        )?;
+
+        // update progress
+        prog_bar.inc(1);
+    }
+
+    prog_bar.finish();
+    Ok(())
+}
 
 /// Executes [RUN_RUN_FILE] script found in `run_folder`.
 ///
@@ -190,6 +344,28 @@ pub fn create_report<T>(
     eval_str
 }
 
+/// Compiles a list of all repetition for each environment, then suffles said list.
+///
+/// The shuffled list is then sorted by repetition, so that all n-repetitions run
+/// before all n+1-repetitions.
+fn shuffle_experiments<'a>(
+    environments: &'a Vec<PathBuf>,
+    repetition_count: &'a u64,
+) -> Vec<(&'a PathBuf, u64)> {
+    let mut running_order = vec![];
+
+    for env in environments {
+        for rep in 0..*repetition_count {
+            running_order.push((env, rep));
+        }
+    }
+
+    running_order.shuffle(&mut rand::rng());
+    running_order.sort_by(|a, b| (a.1).cmp(&b.1));
+
+    return running_order;
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -197,6 +373,7 @@ mod tests {
     use rusty_fork::rusty_fork_test;
     use tempfile::TempDir;
 
+    use super::super::skeleton;
     use super::super::skeleton::{
         build_run_directory, build_series_directory, create_source_directory,
     };
@@ -205,43 +382,172 @@ mod tests {
 
     rusty_fork_test! {
         #[test]
-        fn test_run() {
-            // create base tempdir, to act as parent
+        fn harness_run_e2e() {
+            // create ouput dir
             let tmpdir = TempDir::new().unwrap();
-            let series_dir_handle = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+            std::env::set_current_dir(&tmpdir).unwrap();
+            let exp_name = "SomeExperiment";
+            let out_name = "ExpOutput";
 
-            // create experiment source and series dir
-            let exp_source = TempDir::new_in(tmpdir.path()).unwrap();
-            let exp_source = exp_source.path().to_path_buf();
-            std::env::set_current_dir(&exp_source).unwrap();
-            create_source_directory(&exp_source).unwrap();
+            // build basic experiment
+            skeleton::main(&PathBuf::from(exp_name)).unwrap();
 
-            // write something in run.sh
-            let mut runsh = OpenOptions::new()
+            // Write something to run.sh that uses env var
+            let mut run_sh = OpenOptions::new()
                 .append(true)
-                .open(exp_source.join(SRC_TEMPLATE_DIR).join(SRC_RUN_FILE))
+                .open(
+                    &tmpdir
+                        .join(exp_name)
+                        .join(SRC_TEMPLATE_DIR)
+                        .join(SRC_RUN_FILE),
+                )
+                .unwrap();
+            run_sh
+                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
                 .unwrap();
 
-            writeln!(runsh, "echo $EXP_SRC_DIR").unwrap();
 
-            let series = series_dir_handle.path();
-            build_series_directory(&exp_source, series).unwrap();
+            // let series = series_dir_handle.path();
+            // build_series_directory(&exp_source, series).unwrap();
 
-            let exomat_envs = ExomatEnvironment::new(&exp_source, 0);
-            let default_env = series
-                .join(SERIES_SRC_DIR)
-                .join(SRC_ENV_DIR)
-                .join(SRC_ENV_FILE);
+            // let exomat_envs = ExomatEnvironment::new(&exp_source, 0);
+            // let default_env = series
+            //     .join(SERIES_SRC_DIR)
+            //     .join(SRC_ENV_DIR)
+            //     .join(SRC_ENV_FILE);
 
-            // create run dir and run experiment
-            let run = build_run_directory(series, &default_env, &exomat_envs, 1).unwrap();
-            run_experiment(&file_name_string(&exp_source), &run, &exomat_envs.to_environment_full()).unwrap();
+            // // create run dir and run experiment
+            // let run = build_run_directory(series, &default_env, &exomat_envs, 1).unwrap();
+            // run_experiment(&file_name_string(&exp_source), &run, &exomat_envs.to_environment_full()).unwrap();
 
-            let out_log = std::fs::read_to_string(series.join(SERIES_RUNS_DIR).join(SERIES_STDOUT_LOG)).unwrap();
-            let err_log = std::fs::read_to_string(series.join(SERIES_RUNS_DIR).join(SERIES_STDERR_LOG)).unwrap();
+            // make multiple .env files that set $FOO to different values
+            let mut env1 =
+                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("0.env")).unwrap();
 
-            assert!(out_log.contains(&exp_source.canonicalize().unwrap().display().to_string()));
-            assert!(err_log.is_empty());
+            let mut env2 =
+                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("m.env")).unwrap();
+
+            env1.write_all("FOO=BAR".as_bytes()).unwrap();
+            env2.write_all("FOO=Z".as_bytes()).unwrap();
+
+            // run experiment and check logs
+            experiment(
+                &PathBuf::from(exp_name.to_string()),
+                1,
+                PathBuf::from(out_name),
+                MultiProgress::new(), // empty
+            )
+            .unwrap();
+
+            let stdout_log = std::fs::read_to_string(
+                tmpdir
+                    .join(out_name)
+                    .join(SERIES_RUNS_DIR)
+                    .join(SERIES_STDOUT_LOG),
+            )
+            .unwrap();
+            let stderr_log = std::fs::read_to_string(
+                tmpdir
+                    .join(out_name)
+                    .join(SERIES_RUNS_DIR)
+                    .join(SERIES_STDERR_LOG),
+            )
+            .unwrap();
+
+            assert_eq!(stderr_log.lines().count(), 0);
+            // two lines for variable (inserted here), two lines for current time (part of run.sh template)
+            assert_eq!(dbg!(stdout_log.lines()).count(), 4);
+            assert!(stdout_log.contains("Z"));
+            assert!(stdout_log.contains("BAR"));
+
+            // take one out_file and check its content
+            let output = std::fs::read_to_string(
+                tmpdir
+                    .join(out_name)
+                    .join(SERIES_RUNS_DIR)
+                    .join("run_0_rep0/out_file"),
+            )
+            .unwrap();
+            assert_eq!(output.lines().count(), 1);
+            assert!(output.contains("BAR"));
         }
+
+        #[test]
+        fn trial_e2e() {
+            // create ouput dir
+            let tmpdir = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+            std::env::set_current_dir(&tmpdir).unwrap();
+            let exp_name = "SomeExperiment";
+
+            // build basic experiment
+            skeleton::main(&PathBuf::from(exp_name)).unwrap();
+
+            // Write something to run.sh that uses env var
+            let mut run_sh = OpenOptions::new()
+                .append(true)
+                .open(&tmpdir.join(exp_name).join("template").join("run.sh"))
+                .unwrap();
+            run_sh
+                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
+                .unwrap();
+
+            // make multiple .env files
+            let mut env1 =
+                std::fs::File::create(&tmpdir.join(exp_name).join("envs").join("0.env")).unwrap();
+
+            let env2_path = tmpdir.join(exp_name).join("envs").join("m.env");
+            let mut env2 = std::fs::File::create(&env2_path).unwrap();
+
+            env1.write_all("invalid content".as_bytes()).unwrap(); // should not produce errors, since it is not read
+            env2.write_all("FOO=Z".as_bytes()).unwrap();
+
+            // no error
+            trial(&PathBuf::from(exp_name), env2_path, MultiProgress::new()).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_run() {
+        // create base tempdir, to act as parent
+        let tmpdir = TempDir::new().unwrap();
+        let series_dir_handle = TempDir::new().unwrap();
+
+        // create experiment source and series dir
+        let exp_source = TempDir::new_in(tmpdir.path()).unwrap();
+        let exp_source = exp_source.path().to_path_buf();
+        std::env::set_current_dir(&exp_source).unwrap();
+        create_source_directory(&exp_source).unwrap();
+
+        // write something in run.sh
+        let mut runsh = OpenOptions::new()
+            .append(true)
+            .open(exp_source.join(SRC_TEMPLATE_DIR).join(SRC_RUN_FILE))
+            .unwrap();
+
+        writeln!(runsh, "echo Hello!").unwrap();
+
+        let series = series_dir_handle.path();
+        build_series_directory(&exp_source, series).unwrap();
+        let default_env = series
+            .join(SERIES_SRC_DIR)
+            .join(SRC_ENV_DIR)
+            .join(SRC_ENV_FILE);
+
+        let exomat_env = ExomatEnvironment::new(&exp_source, 1);
+        let env = Environment::from_file(&default_env).unwrap();
+
+        // create run dir and run experiment
+        let run = build_run_directory(series, &default_env, &exomat_env, 1).unwrap();
+        run_experiment(&file_name_string(&exp_source), &run, &env).unwrap();
+
+        let out_log =
+            std::fs::read_to_string(series.join(SERIES_RUNS_DIR).join(SERIES_STDOUT_LOG)).unwrap();
+        let err_log =
+            std::fs::read_to_string(series.join(SERIES_RUNS_DIR).join(SERIES_STDERR_LOG)).unwrap();
+
+        assert!(out_log.contains("Hello!"));
+        assert!(err_log.is_empty());
     }
 }

--- a/src/helper/errors.rs
+++ b/src/helper/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
     #[error("Encountered error while trying to run {experiment}: {err}")]
     HarnessRunError { experiment: String, err: String },
 
-    #[error("Something went wrong in .env generation: {reason:?}")]
+    #[error("Invalid environment: {reason:?}")]
     EnvError { reason: String },
 
     /// Occurs when the make-table command could not generate CSV output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,13 @@ pub mod helper {
     pub mod fs_names;
 }
 
-use chrono::Local;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::MultiProgress;
 use indicatif_log_bridge::LogWrapper;
-use log::{info, trace};
-use rand::seq::SliceRandom;
+use log::info;
 use spdlog::formatter::{pattern, PatternFormatter};
 use spdlog::sink::FileSink;
-use std::{path::Path, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use crate::harness::env::ExomatEnvironment;
 use helper::archivist::find_marker_pwd;
 use helper::errors::{Error, Result};
 use helper::fs_names::*;
@@ -139,178 +136,6 @@ pub fn duplicate_log_to_file(log_file: &PathBuf) {
     spdlog::set_default_logger(new_logger);
 }
 
-/// Creates an experiment series/run directory for the given `experiment`.
-/// Then executes the `run.sh` file for this experiment and dumps the output in
-/// the log files.
-///
-/// The new experiment series directory will either be called `[experiment]-YYYY-MM-DD-HH-MM-SS`
-/// or whatever is defined in `output`.
-///
-/// Requires a directory called `[experiment]` to be present in the current location.
-///
-/// Wrapper around `build_series_directory` and `execute_exp_repetitions`.
-pub fn run_experiment(
-    experiment: &PathBuf,
-    repetitions: u64,
-    output: PathBuf,
-    log_progress_handler: MultiProgress,
-) -> Result<()> {
-    // 1 fetch envs
-    let envs =
-        harness::env::fetch_environment_files(&experiment.join(SRC_ENV_DIR)).ok_or_else(|| {
-            Error::HarnessRunError {
-                experiment: experiment.display().to_string(),
-                err: format!(
-                    "No environments found in {}",
-                    experiment.join(SRC_ENV_DIR).display()
-                ),
-            }
-        })?;
-
-    // 2 build series directory
-    harness::skeleton::build_series_directory(&experiment, &output)?;
-
-    // 3 execute
-    execute_exp_repetitions(
-        &experiment,
-        &output,
-        envs,
-        repetitions,
-        log_progress_handler,
-    )
-}
-
-/// Creates an experiment series/run directory for the given `experiment`.
-/// Then executes the `run.sh` file for this experiment once and collects any
-/// output/errors/results.
-///
-/// The new experiment series directory will be created as a tempdir. The
-pub fn run_trial(
-    experiment: &PathBuf,
-    env: PathBuf,
-    log_progress_handler: MultiProgress,
-) -> Result<()> {
-    // 1 fetch envs a.k.a. check for validity;
-    // The internet told me it's ok to do this just to see if there would be errors
-    harness::env::Environment::from_file(&env)?;
-
-    disable_console_log();
-
-    // 2 build series directory
-    let format = &Local::now()
-        .format("exomat_trial-%Y-%m-%d-%H-%M-%S")
-        .to_string();
-
-    let trial_dir_path = std::env::temp_dir().join(format);
-    harness::skeleton::build_series_directory(experiment, &trial_dir_path)?;
-
-    // 3 execute
-    let res = execute_exp_repetitions(
-        experiment,
-        &trial_dir_path,
-        vec![env],
-        1,
-        log_progress_handler,
-    );
-
-    // 4 gather results
-    spdlog::default_logger().flush();
-
-    let stdout =
-        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDOUT_LOG))?;
-    let stderr =
-        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDERR_LOG))?;
-    let exomat =
-        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_EXOMAT_LOG))?;
-
-    let exp_name = file_name_string(&experiment.canonicalize().unwrap());
-    let eval_res = harness::run::create_report(&exp_name, &res, &stdout, &stderr, &exomat);
-    print!("{eval_res}");
-
-    res
-}
-
-// / Runs the experiment defined in `exp_source_dir` `repetitions` times for each
-/// environment.
-///
-/// This will create a new experiment run folder inside `exp_series_dir`.
-///
-/// This functions assumes that `build_series_directory` has been called before it.
-/// Otherwise it will fail, because the files it expects to be there are not.
-fn execute_exp_repetitions(
-    exp_source_dir: &Path,
-    exp_series_dir: &Path,
-    envs: Vec<PathBuf>,
-    repetitions: u64,
-    log_progress_handler: MultiProgress,
-) -> Result<()> {
-    let length = repetitions.to_string().len();
-
-    let prog_bar = ProgressBar::new(repetitions * envs.len() as u64);
-    prog_bar.set_style(
-        ProgressStyle::with_template("[{elapsed_precise}] [{bar:.green}] {pos}/{len} ({eta})")
-            .unwrap()
-            .progress_chars("#>-"),
-    );
-
-    // protect progress bar from log interferance
-    let prog_bar = log_progress_handler.add(prog_bar);
-    prog_bar.tick(); // show on 0th repetition
-
-    info!("Starting experiment runs for {}", exp_source_dir.display());
-
-    let running_order: Vec<(&PathBuf, u64)> = shuffle_experiments(&envs, &repetitions);
-    for (environment, rep) in running_order {
-        let exomat_envs = ExomatEnvironment::new(&exp_source_dir.to_path_buf(), rep);
-        trace!("exomat envs are: {:?}", exomat_envs.to_environment_full());
-
-        let run_folder = harness::skeleton::build_run_directory(
-            exp_series_dir,
-            &environment,
-            &exomat_envs,
-            length,
-        )?;
-        trace!(
-            "Using envs: {:?}",
-            harness::env::Environment::from_file(&environment)?
-        );
-
-        harness::run::run_experiment(
-            &file_name_string(exp_source_dir),
-            &run_folder,
-            &exomat_envs.to_environment_full(),
-        )?;
-
-        // update progress
-        prog_bar.inc(1);
-    }
-
-    prog_bar.finish();
-    Ok(())
-}
-
-/// Compiles a list of all repetition for each environment, then suffles said list.
-///
-/// The shuffled list is then sorted by repetition, so that all n-repetitions run
-/// before all n+1-repetitions.
-fn shuffle_experiments<'a>(
-    environments: &'a Vec<PathBuf>,
-    repetition_count: &'a u64,
-) -> Vec<(&'a PathBuf, u64)> {
-    let mut running_order = vec![];
-
-    for env in environments {
-        for rep in 0..*repetition_count {
-            running_order.push((env, rep));
-        }
-    }
-
-    running_order.shuffle(&mut rand::rng());
-    running_order.sort_by(|a, b| (a.1).cmp(&b.1));
-
-    return running_order;
-}
-
 /// Filters output (files) from every run repetition in the pwd.
 ///
 /// Looks through every `series_dir/runs/run_*` directory and accumulates the content of
@@ -361,9 +186,6 @@ mod tests {
     use super::*;
 
     use rusty_fork::rusty_fork_test;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use tempfile::TempDir;
 
     use log::{error, info, trace, warn};
     use tempfile::NamedTempFile;
@@ -400,117 +222,5 @@ mod tests {
             assert!(file_content.contains("Error in file"));
             assert!(!file_content.contains("on console"));
         }
-
-
-        #[test]
-        fn harness_run_e2e() {
-            // create ouput dir
-            let tmpdir = TempDir::new().unwrap();
-            let tmpdir = tmpdir.path().to_path_buf();
-            std::env::set_current_dir(&tmpdir).unwrap();
-            let exp_name = "SomeExperiment";
-            let out_name = "ExpOutput";
-
-            // build basic experiment
-            harness::skeleton::main(&PathBuf::from(exp_name)).unwrap();
-
-            // Write something to run.sh that uses env var
-            let mut run_sh = OpenOptions::new()
-                .append(true)
-                .open(
-                    &tmpdir
-                        .join(exp_name)
-                        .join(SRC_TEMPLATE_DIR)
-                        .join(SRC_RUN_FILE),
-                )
-                .unwrap();
-            run_sh
-                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
-                .unwrap();
-
-            // make multiple .env files that set $FOO to different values
-            let mut env1 =
-                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("0.env")).unwrap();
-
-            let mut env2 =
-                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("m.env")).unwrap();
-
-            env1.write_all("FOO=BAR".as_bytes()).unwrap();
-            env2.write_all("FOO=Z".as_bytes()).unwrap();
-
-            // run experiment and check logs
-            run_experiment(
-                &PathBuf::from(exp_name.to_string()),
-                1,
-                PathBuf::from(out_name),
-                MultiProgress::new(), // empty
-            )
-            .unwrap();
-
-            let stdout_log = std::fs::read_to_string(
-                tmpdir
-                    .join(out_name)
-                    .join(SERIES_RUNS_DIR)
-                    .join(SERIES_STDOUT_LOG),
-            )
-            .unwrap();
-            let stderr_log = std::fs::read_to_string(
-                tmpdir
-                    .join(out_name)
-                    .join(SERIES_RUNS_DIR)
-                    .join(SERIES_STDERR_LOG),
-            )
-            .unwrap();
-
-            assert_eq!(stderr_log.lines().count(), 0);
-            // two lines for variable (inserted here), two lines for current time (part of run.sh template)
-            assert_eq!(dbg!(stdout_log.lines()).count(), 4);
-            assert!(stdout_log.contains("Z"));
-            assert!(stdout_log.contains("BAR"));
-
-            // take one out_file and check its content
-            let output = std::fs::read_to_string(
-                tmpdir
-                    .join(out_name)
-                    .join(SERIES_RUNS_DIR)
-                    .join("run_0_rep0/out_file"),
-            )
-            .unwrap();
-            assert_eq!(output.lines().count(), 1);
-            assert!(output.contains("BAR"));
-        }
-    }
-    #[test]
-    fn trial_e2e() {
-        // create ouput dir
-        let tmpdir = TempDir::new().unwrap();
-        let tmpdir = tmpdir.path().to_path_buf();
-        std::env::set_current_dir(&tmpdir).unwrap();
-        let exp_name = "SomeExperiment";
-
-        // build basic experiment
-        harness::skeleton::main(&PathBuf::from(exp_name)).unwrap();
-
-        // Write something to run.sh that uses env var
-        let mut run_sh = OpenOptions::new()
-            .append(true)
-            .open(&tmpdir.join(exp_name).join("template").join("run.sh"))
-            .unwrap();
-        run_sh
-            .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
-            .unwrap();
-
-        // make multiple .env files
-        let mut env1 =
-            std::fs::File::create(&tmpdir.join(exp_name).join("envs").join("0.env")).unwrap();
-
-        let env2_path = tmpdir.join(exp_name).join("envs").join("m.env");
-        let mut env2 = std::fs::File::create(&env2_path).unwrap();
-
-        env1.write_all("invalid content".as_bytes()).unwrap(); // should not produce errors, since it is not read
-        env2.write_all("FOO=Z".as_bytes()).unwrap();
-
-        // no error
-        run_trial(&PathBuf::from(exp_name), env2_path, MultiProgress::new()).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,11 @@ pub fn run_trial(
     env: PathBuf,
     log_progress_handler: MultiProgress,
 ) -> Result<()> {
-    disable_console_log();
+    // 1 fetch envs a.k.a. check for validity;
+    // The internet told me it's ok to do this just to see if there would be errors
+    harness::env::Environment::from_file(&env)?;
 
-    // 1 fetch envs -> given as parameter
+    disable_console_log();
 
     // 2 build series directory
     let format = &Local::now()


### PR DESCRIPTION
Updates and refactors the `exomat run --trial` command.

The option now requires an env file to be provided which it will use for the trial run. A random selection is not an option anymore.

Also adds a clear structure for an `exomat run` call:
1. fetch environments
2. create experiment series dir
3. execute experiment runs
4. only in trial runs: gather output

It also moves all run-related functions from lib.rs into harness/run.rs and/or bin/run.rs (including new tests).