### PR TITLE
fix(env): Don't use value_delimiter=','

### DIFF
--- a/docs/harness.md
+++ b/docs/harness.md
@@ -138,14 +138,14 @@ It is initialized as follows:
 
 Handles (as of now: **generates**) env files _in the current directory_ according to the template.
 
-- `--add VAR VAL1,VAL2,...`:
+- `--add VAR VAL1 VAL2 ...`:
   Adds a variable VAR.
   Can be specified multiple times.
   Aborts if `VAR` is already defined.
 
 ### Example
 
-`exomat harness env --add FOO BAR,BAZ --add X A,B` generates 4 env files:
+`exomat harness env --add FOO BAR BAZ --add X A B` generates 4 env files:
 
 ```
 # 0.env

--- a/src/bin/cli_structure.rs
+++ b/src/bin/cli_structure.rs
@@ -60,7 +60,7 @@ pub enum Commands {
         /// given values.
         ///
         /// For example, if `0.env` contains `FOO=bar` and `1.env`
-        /// contains `FOO=foo` before you execute `exomat harness env --add BAZ 42,69`,
+        /// contains `FOO=foo` before you execute `exomat harness env --add BAZ 42 69`,
         /// the following files will be present after execution:
         /// - 0.env with `FOO=bar`, `BAZ=42`
         /// - 1.env with `FOO=foo`, `BAZ=42`
@@ -69,7 +69,7 @@ pub enum Commands {
         /// > The order of files created does not necessarily represent reality
         ///
         /// Aborts if the variable is already defined.
-        #[arg(short = 'a', long, num_args = 2.., value_delimiter = ',')]
+        #[arg(short = 'a', long, num_args = 2..)]
         add: Vec<Vec<String>>,
 
         /// Edits a variable (first arg) by changing it's values (remaining args) in every .env
@@ -89,7 +89,7 @@ pub enum Commands {
         /// - 2.env with `FOO=bar`, `BAZ=69`
         /// - 3.env with `FOO=foo`, `BAZ=69`
         /// > The order of files created does not necessarily represent reality
-        #[arg(short = 'A', long, num_args = 2.., value_delimiter = ',')]
+        #[arg(short = 'A', long, num_args = 2..)]
         append: Vec<Vec<String>>,
 
         /// Edits a variable (first arg) by removing it's values (remaining args)
@@ -106,7 +106,7 @@ pub enum Commands {
         /// - 0.env with `FOO=bar`
         /// - 1.env with `FOO=foo`
         /// > The order of these files does not necessarily represent reality
-        #[arg(short = 'r', long, num_args = 1.., value_delimiter = ',')]
+        #[arg(short = 'r', long, num_args = 1..)]
         remove: Vec<Vec<String>>,
     },
 

--- a/tests/test_harness_full.sh
+++ b/tests/test_harness_full.sh
@@ -57,7 +57,7 @@ cd $DIR/One
     # should work
     "$EXOMAT_BIN" env
 
-    "$EXOMAT_BIN" env --add ONE foo,bar
+    "$EXOMAT_BIN" env --add ONE foo bar
     test -f $DIR/One/envs/0.env
     test -f $DIR/One/envs/1.env
     test '!' -f $DIR/One/envs/2.env
@@ -79,7 +79,7 @@ cd $DIR/One
     test '!' -f $DIR/One/envs/2.env
 
     # setup for run
-    "$EXOMAT_BIN" env --add ONE foo,bar
+    "$EXOMAT_BIN" env --add ONE foo bar
 cd $DIR
 
 #


### PR DESCRIPTION
CPU sets are commonly expressed as "1,2,4" or "5,6". If I currently create an env for the purpose of running an experiment on different cpu sets, then exomat parses:

```sh
$ exomat env --add FOO 1,2 3,4
```

as

FOO = [ "1", "2", "3", "4"]

instead of

FOO = ["1,2", "3,4"]

This is due to "value_delimiter=','" being set in clap.

As there is no (simple) way to escape this (\\\\,  or \\, does not work). And spaces are perfectly fine delimiters, simply delete value_delimiter=",".