### PR TITLE
Sort functions from lib.rs into modules

### DIFF
--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -20,12 +20,16 @@ pub fn main(
             };
 
             match output {
-                Ok(output) => {
-                    exomat::run_experiment(&experiment, repetitions, output, log_handler, false)
-                }
+                Ok(output) => exomat::harness::run::experiment(
+                    &experiment,
+                    repetitions,
+                    output,
+                    log_handler,
+                    false,
+                ),
                 Err(err) => Err(err),
             }
         }
-        true => exomat::run_trial(&experiment, log_handler),
+        true => exomat::harness::run::trial(&experiment, log_handler),
     }
 }

--- a/src/harness/run.rs
+++ b/src/harness/run.rs
@@ -1,17 +1,184 @@
 //! harness run subcommand
 
+use chrono::Local;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::{error, info, trace, warn};
+use rand::seq::SliceRandom;
 use std::{
     fs::OpenOptions,
     io::Read,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 use strip_ansi::strip_ansi;
 
-use super::env::Environment;
+use super::env::{fetch_environment_files, Environment, ExomatEnvironment};
+use super::skeleton::{build_run_directory, build_series_directory};
 use crate::helper::errors::{Error, Result};
 use crate::helper::fs_names::*;
+
+/// Creates an experiment series/run directory for the given `experiment`.
+/// Then executes the `run.sh` file for this experiment and dumps the output in
+/// the log files.
+///
+/// The new experiment series directory will either be called `[experiment]-YYYY-MM-DD-HH-MM-SS`
+/// or whatever is defined in `output`.
+///
+/// Requires a directory called `[experiment]` to be present in the current location.
+///
+/// Wrapper around `build_series_directory` and `execute_exp_repetitions`.
+pub fn experiment(
+    experiment: &PathBuf,
+    repetitions: u64,
+    output: PathBuf,
+    log_progress_handler: MultiProgress,
+    is_trial: bool,
+) -> Result<()> {
+    build_series_directory(experiment, &output)?;
+    execute_exp_repetitions(
+        experiment,
+        &output,
+        repetitions,
+        log_progress_handler,
+        is_trial,
+    )
+}
+
+/// Creates an experiment series/run directory for the given `experiment`.
+/// Then executes the `run.sh` file for this experiment once and collects any
+/// output/errors/results.
+///
+/// The new experiment series directory will be created as a tempdir.
+pub fn trial(experiment: &PathBuf, log_progress_handler: MultiProgress) -> Result<()> {
+    let exp_name = file_name_string(&experiment.canonicalize().unwrap());
+
+    if experiment.display().to_string() == "." {
+        return Err(Error::HarnessRunError {
+            experiment: exp_name,
+            err: "Cannot start experiment run from the experiment source folder.".to_string(),
+        });
+    }
+
+    let format = &Local::now()
+        .format("exomat_trial-%Y-%m-%d-%H-%M-%S")
+        .to_string();
+
+    let trial_dir_path = std::env::temp_dir().join(format);
+
+    crate::disable_console_log();
+
+    // run experiment once
+    let res = self::experiment(
+        experiment,
+        1,
+        trial_dir_path.clone(),
+        log_progress_handler,
+        true,
+    );
+
+    // flush exomat log
+    spdlog::default_logger().flush();
+
+    // gather results
+    let stdout =
+        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDOUT_LOG))?;
+    let stderr =
+        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDERR_LOG))?;
+    let exomat =
+        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_EXOMAT_LOG))?;
+
+    let eval_res = create_report(&exp_name, &res, &stdout, &stderr, &exomat);
+    print!("{eval_res}");
+
+    res
+}
+
+/// Runs the experiment defined in `exp_source_dir` `repetitions` times for each
+/// environment.
+///
+/// This will create a new experiment run folder inside `exp_series_dir`.
+///
+/// This functions assumes that `build_series_directory` has been called before it.
+/// Otherwise it will fail, because the files it expects to be there are not.
+fn execute_exp_repetitions(
+    exp_source_dir: &Path,
+    exp_series_dir: &Path,
+    repetitions: u64,
+    log_progress_handler: MultiProgress,
+    is_trial: bool,
+) -> Result<()> {
+    let length = repetitions.to_string().len();
+    let envs = fetch_environment_files(&exp_source_dir.join(SRC_ENV_DIR)).ok_or_else(|| {
+        Error::HarnessRunError {
+            experiment: exp_source_dir.display().to_string(),
+            err: format!(
+                "No environments found in {}",
+                exp_source_dir.join(SRC_ENV_DIR).display()
+            ),
+        }
+    })?;
+
+    let prog_bar = ProgressBar::new(repetitions * envs.len() as u64);
+    prog_bar.set_style(
+        ProgressStyle::with_template("[{elapsed_precise}] [{bar:.green}] {pos}/{len} ({eta})")
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    // protect progress bar from log interferance
+    let prog_bar = log_progress_handler.add(prog_bar);
+    prog_bar.tick(); // show on 0th repetition
+
+    info!("Starting experiment runs for {}", exp_source_dir.display());
+
+    let running_order: Vec<(&PathBuf, u64)> = shuffle_experiments(&envs, &repetitions);
+    for (environment, rep) in running_order {
+        let exomat_envs = ExomatEnvironment::new(&exp_source_dir.to_path_buf(), rep);
+        trace!("exomat envs are: {:?}", exomat_envs.to_environment_full());
+
+        let run_folder = build_run_directory(exp_series_dir, &environment, &exomat_envs, length)?;
+        trace!("Using envs: {:?}", Environment::from_file(&environment)?);
+
+        run_experiment(
+            &file_name_string(exp_source_dir),
+            &run_folder,
+            &exomat_envs.to_environment_full(),
+        )?;
+
+        // update progress
+        prog_bar.inc(1);
+
+        // stop after one run if this is a trial
+        if is_trial {
+            break;
+        }
+    }
+
+    prog_bar.finish();
+    Ok(())
+}
+
+/// Compiles a list of all repetition for each environment, then suffles said list.
+///
+/// The shuffled list is then sorted by repetition, so that all n-repetitions run
+/// before all n+1-repetitions.
+fn shuffle_experiments<'a>(
+    environments: &'a Vec<PathBuf>,
+    repetition_count: &'a u64,
+) -> Vec<(&'a PathBuf, u64)> {
+    let mut running_order = vec![];
+
+    for env in environments {
+        for rep in 0..*repetition_count {
+            running_order.push((env, rep));
+        }
+    }
+
+    running_order.shuffle(&mut rand::rng());
+    running_order.sort_by(|a, b| (a.1).cmp(&b.1));
+
+    return running_order;
+}
 
 /// Executes [RUN_RUN_FILE] script found in `run_folder`.
 ///
@@ -28,7 +195,7 @@ use crate::helper::fs_names::*;
 /// - Returns a `HarnessRunrror` if [RUN_RUN_FILE] could not be executed
 /// - panics if there is no [RUN_RUN_FILE] in `run_folder`
 /// - panics if there is no [RUN_ENV_FILE] in `run_folder`
-pub fn run_experiment(exp_name: &str, run_folder: &Path, exomat_envs: &Environment) -> Result<()> {
+fn run_experiment(exp_name: &str, run_folder: &Path, exomat_envs: &Environment) -> Result<()> {
     assert!(
         run_folder.join(RUN_RUN_FILE).is_file(),
         "Missing run.sh in experiment run directory"
@@ -242,6 +409,119 @@ mod tests {
 
             assert!(out_log.contains(&exp_source.canonicalize().unwrap().display().to_string()));
             assert!(err_log.is_empty());
+        }
+
+        #[test]
+        fn harness_run_e2e() {
+            // create ouput dir
+            let tmpdir = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+            std::env::set_current_dir(&tmpdir).unwrap();
+            let exp_name = "SomeExperiment";
+            let out_name = "ExpOutput";
+
+            // build basic experiment
+            crate::harness::skeleton::main(&PathBuf::from(exp_name)).unwrap();
+
+            // Write something to run.sh that uses env var
+            let mut run_sh = OpenOptions::new()
+                .append(true)
+                .open(
+                    &tmpdir
+                        .join(exp_name)
+                        .join(SRC_TEMPLATE_DIR)
+                        .join(SRC_RUN_FILE),
+                )
+                .unwrap();
+            run_sh
+                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
+                .unwrap();
+
+            // make multiple .env files that set $FOO to different values
+            let mut env1 =
+                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("0.env")).unwrap();
+
+            let mut env2 =
+                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("m.env")).unwrap();
+
+            env1.write_all("FOO=BAR".as_bytes()).unwrap();
+            env2.write_all("FOO=Z".as_bytes()).unwrap();
+
+            // run experiment and check logs
+            experiment(
+                &PathBuf::from(exp_name.to_string()),
+                1,
+                PathBuf::from(out_name),
+                MultiProgress::new(), // empty
+                false
+            )
+            .unwrap();
+
+            let stdout_log = std::fs::read_to_string(
+                tmpdir
+                    .join(out_name)
+                    .join(SERIES_RUNS_DIR)
+                    .join(SERIES_STDOUT_LOG),
+            )
+            .unwrap();
+            let stderr_log = std::fs::read_to_string(
+                tmpdir
+                    .join(out_name)
+                    .join(SERIES_RUNS_DIR)
+                    .join(SERIES_STDERR_LOG),
+            )
+            .unwrap();
+
+            assert_eq!(stderr_log.lines().count(), 0);
+            // two lines for variable (inserted here), two lines for current time (part of run.sh template)
+            assert_eq!(dbg!(stdout_log.lines()).count(), 4);
+            assert!(stdout_log.contains("Z"));
+            assert!(stdout_log.contains("BAR"));
+
+            // take one out_file and check its content
+            let output = std::fs::read_to_string(
+                tmpdir
+                    .join(out_name)
+                    .join(SERIES_RUNS_DIR)
+                    .join("run_0_rep0/out_file"),
+            )
+            .unwrap();
+            assert_eq!(output.lines().count(), 1);
+            assert!(output.contains("BAR"));
+        }
+
+        #[test]
+        fn trial_e2e() {
+            // create ouput dir
+            let tmpdir = TempDir::new().unwrap();
+            let tmpdir = tmpdir.path().to_path_buf();
+            std::env::set_current_dir(&tmpdir).unwrap();
+            let exp_name = "SomeExperiment";
+
+            // build basic experiment
+            crate::harness::skeleton::main(&PathBuf::from(exp_name)).unwrap();
+
+            // Write something to run.sh that uses env var
+            let mut run_sh = OpenOptions::new()
+                .append(true)
+                .open(&tmpdir.join(exp_name).join("template").join("run.sh"))
+                .unwrap();
+            run_sh
+                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
+                .unwrap();
+
+            // make multiple .env files that set $FOO to different values
+            let mut env1 =
+                std::fs::File::create(&tmpdir.join(exp_name).join("envs").join("0.env")).unwrap();
+
+            let mut env2 =
+                std::fs::File::create(&tmpdir.join(exp_name).join("envs").join("m.env")).unwrap();
+
+            env1.write_all("FOO=BAR".as_bytes()).unwrap();
+            env2.write_all("FOO=Z".as_bytes()).unwrap();
+
+            // no error
+            trial(&PathBuf::from(exp_name), MultiProgress::new()).unwrap();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,13 @@ pub mod helper {
     pub mod fs_names;
 }
 
-use chrono::Local;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::MultiProgress;
 use indicatif_log_bridge::LogWrapper;
-use log::{info, trace};
-use rand::seq::SliceRandom;
+use log::info;
 use spdlog::formatter::{pattern, PatternFormatter};
 use spdlog::sink::FileSink;
-use std::{path::Path, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use crate::harness::env::ExomatEnvironment;
 use helper::archivist::find_marker_pwd;
 use helper::errors::{Error, Result};
 use helper::fs_names::*;
@@ -139,176 +136,6 @@ pub fn duplicate_log_to_file(log_file: &PathBuf) {
     spdlog::set_default_logger(new_logger);
 }
 
-/// Creates an experiment series/run directory for the given `experiment`.
-/// Then executes the `run.sh` file for this experiment and dumps the output in
-/// the log files.
-///
-/// The new experiment series directory will either be called `[experiment]-YYYY-MM-DD-HH-MM-SS`
-/// or whatever is defined in `output`.
-///
-/// Requires a directory called `[experiment]` to be present in the current location.
-///
-/// Wrapper around `build_series_directory` and `execute_exp_repetitions`.
-pub fn run_experiment(
-    experiment: &PathBuf,
-    repetitions: u64,
-    output: PathBuf,
-    log_progress_handler: MultiProgress,
-    is_trial: bool,
-) -> Result<()> {
-    harness::skeleton::build_series_directory(experiment, &output)?;
-    execute_exp_repetitions(
-        experiment,
-        &output,
-        repetitions,
-        log_progress_handler,
-        is_trial,
-    )
-}
-
-/// Creates an experiment series/run directory for the given `experiment`.
-/// Then executes the `run.sh` file for this experiment once and collects any
-/// output/errors/results.
-///
-/// The new experiment series directory will be created as a tempdir. The
-pub fn run_trial(experiment: &PathBuf, log_progress_handler: MultiProgress) -> Result<()> {
-    let exp_name = file_name_string(&experiment.canonicalize().unwrap());
-
-    if experiment.display().to_string() == "." {
-        return Err(Error::HarnessRunError {
-            experiment: exp_name,
-            err: "Cannot start experiment run from the experiment source folder.".to_string(),
-        });
-    }
-
-    let format = &Local::now()
-        .format("exomat_trial-%Y-%m-%d-%H-%M-%S")
-        .to_string();
-
-    let trial_dir_path = std::env::temp_dir().join(format);
-
-    disable_console_log();
-
-    // run experiment once
-    let res = run_experiment(
-        experiment,
-        1,
-        trial_dir_path.clone(),
-        log_progress_handler,
-        true,
-    );
-
-    // flush exomat log
-    spdlog::default_logger().flush();
-
-    // gather results
-    let stdout =
-        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDOUT_LOG))?;
-    let stderr =
-        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_STDERR_LOG))?;
-    let exomat =
-        std::fs::read_to_string(trial_dir_path.join(SERIES_RUNS_DIR).join(SERIES_EXOMAT_LOG))?;
-
-    let eval_res = harness::run::create_report(&exp_name, &res, &stdout, &stderr, &exomat);
-    print!("{eval_res}");
-
-    res
-}
-
-// / Runs the experiment defined in `exp_source_dir` `repetitions` times for each
-/// environment.
-///
-/// This will create a new experiment run folder inside `exp_series_dir`.
-///
-/// This functions assumes that `build_series_directory` has been called before it.
-/// Otherwise it will fail, because the files it expects to be there are not.
-fn execute_exp_repetitions(
-    exp_source_dir: &Path,
-    exp_series_dir: &Path,
-    repetitions: u64,
-    log_progress_handler: MultiProgress,
-    is_trial: bool,
-) -> Result<()> {
-    let length = repetitions.to_string().len();
-    let envs = harness::env::fetch_environment_files(&exp_source_dir.join(SRC_ENV_DIR))
-        .ok_or_else(|| Error::HarnessRunError {
-            experiment: exp_source_dir.display().to_string(),
-            err: format!(
-                "No environments found in {}",
-                exp_source_dir.join(SRC_ENV_DIR).display()
-            ),
-        })?;
-
-    let prog_bar = ProgressBar::new(repetitions * envs.len() as u64);
-    prog_bar.set_style(
-        ProgressStyle::with_template("[{elapsed_precise}] [{bar:.green}] {pos}/{len} ({eta})")
-            .unwrap()
-            .progress_chars("#>-"),
-    );
-
-    // protect progress bar from log interferance
-    let prog_bar = log_progress_handler.add(prog_bar);
-    prog_bar.tick(); // show on 0th repetition
-
-    info!("Starting experiment runs for {}", exp_source_dir.display());
-
-    let running_order: Vec<(&PathBuf, u64)> = shuffle_experiments(&envs, &repetitions);
-    for (environment, rep) in running_order {
-        let exomat_envs = ExomatEnvironment::new(&exp_source_dir.to_path_buf(), rep);
-        trace!("exomat envs are: {:?}", exomat_envs.to_environment_full());
-
-        let run_folder = harness::skeleton::build_run_directory(
-            exp_series_dir,
-            &environment,
-            &exomat_envs,
-            length,
-        )?;
-        trace!(
-            "Using envs: {:?}",
-            harness::env::Environment::from_file(&environment)?
-        );
-
-        harness::run::run_experiment(
-            &file_name_string(exp_source_dir),
-            &run_folder,
-            &exomat_envs.to_environment_full(),
-        )?;
-
-        // update progress
-        prog_bar.inc(1);
-
-        // stop after one run if this is a trial
-        if is_trial {
-            break;
-        }
-    }
-
-    prog_bar.finish();
-    Ok(())
-}
-
-/// Compiles a list of all repetition for each environment, then suffles said list.
-///
-/// The shuffled list is then sorted by repetition, so that all n-repetitions run
-/// before all n+1-repetitions.
-fn shuffle_experiments<'a>(
-    environments: &'a Vec<PathBuf>,
-    repetition_count: &'a u64,
-) -> Vec<(&'a PathBuf, u64)> {
-    let mut running_order = vec![];
-
-    for env in environments {
-        for rep in 0..*repetition_count {
-            running_order.push((env, rep));
-        }
-    }
-
-    running_order.shuffle(&mut rand::rng());
-    running_order.sort_by(|a, b| (a.1).cmp(&b.1));
-
-    return running_order;
-}
-
 /// Filters output (files) from every run repetition in the pwd.
 ///
 /// Looks through every `series_dir/runs/run_*` directory and accumulates the content of
@@ -358,12 +185,8 @@ pub fn make_table() -> Result<()> {
 mod tests {
     use super::*;
 
-    use rusty_fork::rusty_fork_test;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use tempfile::TempDir;
-
     use log::{error, info, trace, warn};
+    use rusty_fork::rusty_fork_test;
     use tempfile::NamedTempFile;
 
     rusty_fork_test! {
@@ -397,120 +220,6 @@ mod tests {
             assert!(file_content.contains("Warn in file"));
             assert!(file_content.contains("Error in file"));
             assert!(!file_content.contains("on console"));
-        }
-
-
-        #[test]
-        fn harness_run_e2e() {
-            // create ouput dir
-            let tmpdir = TempDir::new().unwrap();
-            let tmpdir = tmpdir.path().to_path_buf();
-            std::env::set_current_dir(&tmpdir).unwrap();
-            let exp_name = "SomeExperiment";
-            let out_name = "ExpOutput";
-
-            // build basic experiment
-            harness::skeleton::main(&PathBuf::from(exp_name)).unwrap();
-
-            // Write something to run.sh that uses env var
-            let mut run_sh = OpenOptions::new()
-                .append(true)
-                .open(
-                    &tmpdir
-                        .join(exp_name)
-                        .join(SRC_TEMPLATE_DIR)
-                        .join(SRC_RUN_FILE),
-                )
-                .unwrap();
-            run_sh
-                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
-                .unwrap();
-
-            // make multiple .env files that set $FOO to different values
-            let mut env1 =
-                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("0.env")).unwrap();
-
-            let mut env2 =
-                std::fs::File::create(&tmpdir.join(exp_name).join(SRC_ENV_DIR).join("m.env")).unwrap();
-
-            env1.write_all("FOO=BAR".as_bytes()).unwrap();
-            env2.write_all("FOO=Z".as_bytes()).unwrap();
-
-            // run experiment and check logs
-            run_experiment(
-                &PathBuf::from(exp_name.to_string()),
-                1,
-                PathBuf::from(out_name),
-                MultiProgress::new(), // empty
-                false
-            )
-            .unwrap();
-
-            let stdout_log = std::fs::read_to_string(
-                tmpdir
-                    .join(out_name)
-                    .join(SERIES_RUNS_DIR)
-                    .join(SERIES_STDOUT_LOG),
-            )
-            .unwrap();
-            let stderr_log = std::fs::read_to_string(
-                tmpdir
-                    .join(out_name)
-                    .join(SERIES_RUNS_DIR)
-                    .join(SERIES_STDERR_LOG),
-            )
-            .unwrap();
-
-            assert_eq!(stderr_log.lines().count(), 0);
-            // two lines for variable (inserted here), two lines for current time (part of run.sh template)
-            assert_eq!(dbg!(stdout_log.lines()).count(), 4);
-            assert!(stdout_log.contains("Z"));
-            assert!(stdout_log.contains("BAR"));
-
-            // take one out_file and check its content
-            let output = std::fs::read_to_string(
-                tmpdir
-                    .join(out_name)
-                    .join(SERIES_RUNS_DIR)
-                    .join("run_0_rep0/out_file"),
-            )
-            .unwrap();
-            assert_eq!(output.lines().count(), 1);
-            assert!(output.contains("BAR"));
-        }
-
-        #[test]
-        fn trial_e2e() {
-            // create ouput dir
-            let tmpdir = TempDir::new().unwrap();
-            let tmpdir = tmpdir.path().to_path_buf();
-            std::env::set_current_dir(&tmpdir).unwrap();
-            let exp_name = "SomeExperiment";
-
-            // build basic experiment
-            harness::skeleton::main(&PathBuf::from(exp_name)).unwrap();
-
-            // Write something to run.sh that uses env var
-            let mut run_sh = OpenOptions::new()
-                .append(true)
-                .open(&tmpdir.join(exp_name).join("template").join("run.sh"))
-                .unwrap();
-            run_sh
-                .write("echo $FOO\necho $FOO >> out_file".as_bytes()) // write to stdout and in file
-                .unwrap();
-
-            // make multiple .env files that set $FOO to different values
-            let mut env1 =
-                std::fs::File::create(&tmpdir.join(exp_name).join("envs").join("0.env")).unwrap();
-
-            let mut env2 =
-                std::fs::File::create(&tmpdir.join(exp_name).join("envs").join("m.env")).unwrap();
-
-            env1.write_all("FOO=BAR".as_bytes()).unwrap();
-            env2.write_all("FOO=Z".as_bytes()).unwrap();
-
-            // no error
-            run_trial(&PathBuf::from(exp_name), MultiProgress::new()).unwrap();
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> ExitCode {
             append,
             remove,
         } => exomat::harness::env::main(add, append, remove),
-        Commands::MakeTable {} => exomat::make_table(),
+        Commands::MakeTable {} => exomat::harness::table::main(),
         Commands::Completion { shell } => bin::completion::main(shell),
     };
 


### PR DESCRIPTION
Currently, there are some functions in `lib.rs` that would make more sense in another module.

Namely the entry point for `exomat run`, `exomat run --trial` and `exomat make-table` (among other helper functions).

This PR sorts them all into the corresponding modules and edits unit tests accordingly.